### PR TITLE
Add support for deployment in Cloud Run

### DIFF
--- a/image_scraper/docker-compose.yaml
+++ b/image_scraper/docker-compose.yaml
@@ -14,16 +14,7 @@ services:
       IMAGES_BUCKET_NAME: ${IMAGES_BUCKET_NAME}
       PROJECT_ID: ${PROJECT_ID}
       KAFKA_LISTENER: ${KAFKA_LISTENER}
-
-  scrapyd_deploy:
-    container_name: scrapyd_deploy
-    build:
-      context: .
-      dockerfile: scrapyd_deploy.Dockerfile
-    volumes:
-      - ${PWD}/image_scraper/image_scraper:/src/image_scraper
-    depends_on:
-      - scrapyd
+      DEPLOY_ENV: "docker"
 
   # Kafka Server
   zookeeper-service:

--- a/image_scraper/entrypoint.sh
+++ b/image_scraper/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Start the Scrapyd service in the background and log to file
+scrapyd > scrapyd.log 2>&1 &
+
+# Give Scrapyd some time to start
+sleep 5
+
+# Run scrapyd-deploy
+scrapyd-deploy "$1"
+
+# Tail the logs to hold foreground
+tail -f scrapyd.log

--- a/image_scraper/scrapy.cfg
+++ b/image_scraper/scrapy.cfg
@@ -13,3 +13,7 @@ project = image_scraper
 [deploy:docker]
 url = http://scrapyd:6800/
 project = image_scraper
+
+[deploy:cloudrun]
+url = $CLOUDRUN_URL
+project = image_scraper

--- a/image_scraper/scrapyd.Dockerfile
+++ b/image_scraper/scrapyd.Dockerfile
@@ -10,17 +10,27 @@ RUN apt-get install -y google-chrome-stable
 
 # set display port to avoid crash
 ENV DISPLAY=:99
+ENV DEPLOY_ENV=cloudrun
 
+WORKDIR /src
+
+# In the future replace with dockerignore
+COPY image_scraper /src/image_scraper
+COPY tests /src/tests
+COPY requirements.txt /src
+COPY scrapy.cfg /src
 COPY scrapyd.conf /etc/scrapyd/scrapyd.conf
 COPY requirements.txt .
 COPY service_account.json .
+COPY entrypoint.sh /
 
-ENV GOOGLE_APPLICATION_CREDENTIALS /service_account.json
+ENV GOOGLE_APPLICATION_CREDENTIALS /src/service_account.json
 
 RUN pip install -r requirements.txt
+RUN chmod +x /entrypoint.sh
 
 # Expost default Scrapyd port 6800
 EXPOSE 6800
 
 # Start Scrapyd server when container is run
-CMD ["scrapyd"]
+CMD /entrypoint.sh $DEPLOY_ENV


### PR DESCRIPTION
The code changes add deployment support for Google Cloud Run. Configuration settings have been appended in `scrapy.cfg` for cloud run deployment. Adjustments have also been made in `docker-compose.yaml`, `scrapyd.Dockerfile`, and a new `entrypoint.sh` is created to manage deployment based on environment variables. This allows the image scraper to be deployed in both Docker and Cloud Run environments.